### PR TITLE
reallow adding index page(s) to breadcrumbs

### DIFF
--- a/app/views/alchemy/pages/show.rb
+++ b/app/views/alchemy/pages/show.rb
@@ -119,11 +119,11 @@ module Alchemy::Pages
       end
 
       # Temporary replacement until foyer is ready
-      crumbs[0] = {
+      crumbs.unshift({
         url: europeana_collections_url,
         title: t('site.navigation.breadcrumb.return_home', default: 'Return to Home'),
         is_first: true
-      }
+      })
 
       crumbs.last[:is_last] = true
       crumbs


### PR DESCRIPTION
the return to home link was overwriting the index pages, adding it to the start of the crumbs array means index pages show up in breadcrumbs.