### PR TITLE
Fix OG:image urls

### DIFF
--- a/app/helpers/picture_version_helper.rb
+++ b/app/helpers/picture_version_helper.rb
@@ -30,13 +30,22 @@ module PictureVersionHelper
   end
 
   ##
-  # Looks up the remote url for a Alchemy::PictureVersion, only works for S3DataStore.
+  # Looks up the remote url for a Alchemy::PictureVersion.
   #
   # @param version_picture [Alchemy::PictureVersion]
   def picture_version_url(version)
     if Dragonfly.app(:alchemy_pictures).datastore.is_a?(Dragonfly::S3DataStore)
       Dragonfly.app(:alchemy_pictures).datastore.url_for(version.file_uuid).sub(%r(\Ahttp://), 'https://')
+    else
+      full_url(version.file_uuid)
     end
+  end
+
+  def full_url(file_uuid)
+    host = ENV.fetch('CDN_HOST', ENV.fetch('APP_HOST', 'localhost'))
+    protocol = host == 'localhost' ? 'http' : 'https'
+    port = ENV.fetch('APP_PORT', nil)
+    "#{protocol}://#{host}#{port.nil? ? '' : ':' + port}#{file_uuid}"
   end
 
   #

--- a/lib/europeana/page.rb
+++ b/lib/europeana/page.rb
@@ -366,13 +366,6 @@ module Europeana
       false
     end
 
-    def full_url(path)
-      host = ENV.fetch('CDN_HOST', ENV.fetch('APP_HOST', 'localhost'))
-      protocol = host == 'localhost' ? 'http' : 'https'
-      port = ENV.fetch('APP_PORT', nil)
-      "#{protocol}://#{host}#{port.nil? ? '' : ':' + port}#{path}"
-    end
-
     private
 
     def prepend_portal_breadcrumb(crumbs)

--- a/lib/europeana/page.rb
+++ b/lib/europeana/page.rb
@@ -361,7 +361,7 @@ module Europeana
 
     def thumbnail(version = :full)
       if chapter_thumbnail&.key?(:image)
-        return full_url(chapter_thumbnail[:image][version][:url])
+        return chapter_thumbnail[:image][version][:url]
       end
       false
     end

--- a/spec/fixtures/alchemy/elements.yml
+++ b/spec/fixtures/alchemy/elements.yml
@@ -1,3 +1,4 @@
+
 text_element:
   name: 'text'
   public: true

--- a/spec/fixtures/alchemy/elements.yml
+++ b/spec/fixtures/alchemy/elements.yml
@@ -1,4 +1,3 @@
-
 text_element:
   name: 'text'
   public: true


### PR DESCRIPTION
Remove the addition of protocol + hostname + port, by moving the full_url call out of the thumbnail method in the Europeana::Page class.

The full_url isn't necessary where an image version is stored in S3 as these versions already contain the full url.

For compatibility on localhost without S3 storage configured(not tested though, since we always use S3 storage on production instances) and in order to not break tests, the full_url method has been moved to the picture_version_helper to be used when no S3DataStore is configured.